### PR TITLE
Fixed: updated megacloud url to latest

### DIFF
--- a/src/providers/embeds/megacloud/upcloud.ts
+++ b/src/providers/embeds/megacloud/upcloud.ts
@@ -23,7 +23,7 @@ export const megaCloudScraper = makeEmbed({
     const dataId = dataPath[dataPath.length - 1];
 
     const streamRes = await ctx.proxiedFetcher<StreamRes>(
-      `${parsedUrl.origin}/embed-1/ajax/e-1/getSources?id=${dataId}`,
+      `${parsedUrl.origin}/embed-2/ajax/e-1/getSources?id=${dataId}`,
       {
         headers: {
           Referer: parsedUrl.origin,


### PR DESCRIPTION
This pull request resolves megacloud old url

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] I have tested all of my changes.
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
